### PR TITLE
Ensure hidden member are not enumerated and fix map names

### DIFF
--- a/reference-gen/pkg/generator/generator.go
+++ b/reference-gen/pkg/generator/generator.go
@@ -149,6 +149,7 @@ func (g *generator) buildTemplate(typesToRender map[*types.Type][]*types.Type, t
 		"dereference":      tryDereference,
 		"fieldEmbedded":    fieldEmbedded,
 		"fieldName":        fieldName,
+		"hideMember":       hideMember,
 		"isOptionalMember": isOptionalMember,
 		"linkForType":      linkForTypeFunc(knownTypes),
 		"renderCommentsBR": renderCommentsBR,
@@ -156,6 +157,7 @@ func (g *generator) buildTemplate(typesToRender map[*types.Type][]*types.Type, t
 		"sortedTypes":      sortTypes,
 		"typeDisplayName":  typeDisplayNameFunc(knownTypes),
 		"typeReferences":   typeReferencesFunc(typesToRender, knownTypes),
+		"visibleMembers":   visibleMembers,
 		"visibleTypes":     visibleTypes,
 	})
 

--- a/reference-gen/pkg/generator/templates.go
+++ b/reference-gen/pkg/generator/templates.go
@@ -25,7 +25,7 @@ const packageTemplate = `
 const typeTemplate = `
 {{ define "type" }}
 ### {{ .Name.Name }}
-{{- if eq .Kind "Alias" }}
+{{- if or (eq .Kind "Alias") (aliasDisplayName .) }}
 {{ if linkForType .Underlying }}
 #### ([{{ aliasDisplayName . }}]({{ linkForType .Underlying}}) alias)
 {{- else -}}
@@ -43,7 +43,7 @@ const typeTemplate = `
 {{ end }}
 {{ renderCommentsLF .CommentLines }}
 
-{{ if .Members -}}
+{{ if visibleMembers .Members -}}
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 {{- template "members_with_embed" . }}
@@ -53,6 +53,7 @@ const typeTemplate = `
 
 const memberTemplate = `
 {{ define "member" }}
+  {{- if not (hideMember .) }}
 | {{ backtick (fieldName .) }} | _{{- if linkForType .Type -}}
     [{{ typeDisplayName .Type }}]({{ linkForType .Type}})
   {{- else -}}
@@ -62,6 +63,7 @@ const memberTemplate = `
   {{ end -}}
   {{- if isOptionalMember . }} _(Optional)_ {{ end -}}
   {{- renderCommentsBR .CommentLines }} |
+  {{- end -}}
 {{- end }}
 `
 

--- a/reference-gen/pkg/generator/utils.go
+++ b/reference-gen/pkg/generator/utils.go
@@ -120,7 +120,11 @@ func aliasDisplayName(t *types.Type, knownTypes typeSet) string {
 		return alias[0]
 	}
 
-	return typeDisplayName(t.Underlying, knownTypes)
+	if t.Underlying != nil {
+		return typeDisplayName(t.Underlying, knownTypes)
+	}
+
+	return ""
 }
 
 // anchorIDForLocalType returns the #anchor string for the local type
@@ -159,6 +163,11 @@ func filterCommentTags(comments []string) []string {
 	return out
 }
 
+// hideMember determines if a member is to private
+func hideMember(m types.Member) bool {
+	return unicode.IsLower(rune(m.Name[0]))
+}
+
 // hideType determines if a type is to private
 func hideType(t *types.Type) bool {
 	return unicode.IsLower(rune(t.Name.Name[0]))
@@ -181,6 +190,10 @@ func linkForTypeFunc(knownTypes typeSet) func(t *types.Type) string {
 // linkForType returns an anchor to the type if it can be generated. returns
 // empty string if it is not a local type or unrecognized external type.
 func linkForType(t *types.Type, knownTypes typeSet) string {
+	if t == nil {
+		return ""
+	}
+
 	t = tryDereference(t) // dereference kind=Pointer
 
 	if knownTypes.has(t) {
@@ -281,6 +294,17 @@ func typeReferences(t *types.Type, references map[*types.Type][]*types.Type, kno
 		}
 	}
 	sortTypes(out)
+	return out
+}
+
+// visibleMembers filters the members to only those that are exported
+func visibleMembers(in []types.Member) []types.Member {
+	var out []types.Member
+	for _, t := range in {
+		if !hideMember(t) {
+			out = append(out, t)
+		}
+	}
 	return out
 }
 

--- a/reference-gen/pkg/generator/utils.go
+++ b/reference-gen/pkg/generator/utils.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -255,8 +256,8 @@ func typeDisplayName(t *types.Type, knownTypes typeSet) string {
 		types.Builtin:
 		// noop
 	case types.Map:
-		// return original name
-		return t.Name.Name
+		// construct map based on element name
+		return fmt.Sprintf("map[%s]%s", t.Key.Name.Name, s)
 	default:
 		klog.Fatalf("type %s has kind=%v which is unhandled", t.Name, t.Kind)
 	}


### PR DESCRIPTION
This updates the code to ensure that maps are named correctly when the map is a known type element and also make sure that if a struct has hidden members, these aren't printed

I'm intending to follow up with a test suite soon