### PR TITLE
chore(ci): upgrade golangci-lint to v2.0.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Get dependencies
       env:
-        GOLANGCI_LINT_VERSION: v1.63.4
+        GOLANGCI_LINT_VERSION: v2.0.2
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
Upgrade golangci-lint to v2.0.2 from v1.63.4.

There isn't a .golangci.yml configuration in the repo, so let's just use the new defaults of v2.

v2 changelog: https://github.com/golangci/golangci-lint/releases/tag/v2.0.0

Reminder: this isn't the main oauth2-proxy repo. This repo contains only tooling for code generation.